### PR TITLE
feat(api): add `ignoreSecrets` option to `load`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * [What happens with secrets that are disabled?](#what-happens-with-secrets-that-are-disabled)
 * [How are secrets with multiple versions handled?](#how-are-secrets-with-multiple-versions-handled)
 * [Can secret names be prefixed with the runtime environment?](#can-secret-names-be-prefixed-with-the-runtime-environment)
+* [Is there a way to disable reading secrets at runtime?](#is-there-a-way-to-disable-reading-secrets-at-runtime)
 * [How do I run the tests?](#how-do-i-run-the-tests)
 * [What versions of Node does it support?](#what-versions-of-node-does-it-support)
 * [Is there a changelog?](#is-there-a-changelog)
@@ -329,6 +330,34 @@ const config = await gcpConfig.load({
   },
 });
 ```
+
+## Is there a way to disable reading secrets at runtime?
+
+Yes.
+Secrets will not be loaded
+if the `ignoreSecrets` option to `load` is `true`:
+
+```js
+const config = await gcpConfig.load({
+  ignoreSecrets: process.env.NODE_ENV === 'test',
+
+  project: process.env.GCP_PROJECT,
+
+  schema: {
+    foo: {
+      default: 'default value',
+      // Won't be loaded when `NODE_ENV` is `test`
+      secret: 'foo',
+    },
+  },
+});
+```
+
+This can be useful in test environments,
+when running many tests in quick succession
+can exceed the available read quota
+for Secret Manager.
+Nobody likes flaky tests.
 
 ## How do I run the tests?
 

--- a/src/build-config.js
+++ b/src/build-config.js
@@ -10,8 +10,22 @@ const readValue = require('./read-value');
 
 module.exports = buildConfig;
 
-async function buildConfig({ client, file, prefix, project, schema }) {
-  let value = await readValue({ client, file, prefix, project, schema });
+async function buildConfig({
+  client,
+  file,
+  ignoreSecrets,
+  prefix,
+  project,
+  schema,
+}) {
+  let value = await readValue({
+    client,
+    file,
+    ignoreSecrets,
+    prefix,
+    project,
+    schema,
+  });
 
   if (value !== undefined) {
     if (schema.schema) {
@@ -39,6 +53,7 @@ async function buildConfig({ client, file, prefix, project, schema }) {
         const childValue = await buildConfig({
           client,
           file: file?.[key],
+          ignoreSecrets,
           prefix,
           project,
           schema: value,

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,8 @@ module.exports = {
   load,
 };
 
-async function load({ file, prefix, project, schema }) {
+async function load({ file, ignoreSecrets, prefix, project, schema }) {
+  assert.maybe.boolean(ignoreSecrets);
   assert.maybe.nonEmptyString(file);
   assert.maybe.nonEmptyString(prefix);
   assert.nonEmptyString(project);
@@ -23,5 +24,5 @@ async function load({ file, prefix, project, schema }) {
     file = JSON.parse(await fs.readFile(file, 'utf8'));
   }
 
-  return buildConfig({ client, file, prefix, project, schema });
+  return buildConfig({ client, file, ignoreSecrets, prefix, project, schema });
 }

--- a/src/read-value.js
+++ b/src/read-value.js
@@ -2,7 +2,14 @@
 
 module.exports = readValue;
 
-async function readValue({ client, file, prefix, project, schema }) {
+async function readValue({
+  client,
+  file,
+  ignoreSecrets,
+  prefix,
+  project,
+  schema,
+}) {
   const { env } = schema;
 
   if (env && process.env[env]) {
@@ -10,7 +17,7 @@ async function readValue({ client, file, prefix, project, schema }) {
   }
 
   let secret = schema.secret || env;
-  if (secret) {
+  if (secret && !ignoreSecrets) {
     if (prefix) {
       secret = `${prefix}${secret}`;
     }

--- a/test/precedence.js
+++ b/test/precedence.js
@@ -235,6 +235,35 @@ suite('precedence:', () => {
     });
   });
 
+  suite('ignore secrets:', () => {
+    let secrets;
+
+    suiteSetup(async () => {
+      process.env[ENV.foo] = 'foo set from environment';
+      secrets = await setupSecrets(client);
+      config = await impl.load({
+        ignoreSecrets: true,
+        project: GCP_PROJECT,
+        schema: SCHEMA,
+      });
+    });
+
+    suiteTeardown(async () => {
+      await teardownSecrets(client, secrets);
+      delete process.env[ENV.foo];
+    });
+
+    test('result was correct', () => {
+      assert.deepEqual(config, {
+        foo: 'foo set from environment',
+        bar: DEFAULTS.bar,
+        qux: {
+          blee: DEFAULTS.blee,
+        },
+      });
+    });
+  });
+
   suite('load file:', () => {
     let file;
 


### PR DESCRIPTION
Monorepo tests are failing with quota exceeded errors as we try to load secrets every time. This option enables us to skip secrets under test, using default values or whatever instead.