### PR TITLE
chore(read-value): skip read-value when secret is not string

### DIFF
--- a/src/read-value.js
+++ b/src/read-value.js
@@ -21,16 +21,19 @@ async function readValue({
   project,
   schema,
 }) {
-  let { env } = schema;
+  let { env, secret: schemaSecret } = schema;
   if (typeof env !== 'string') {
     env = undefined;
+  }
+  if (typeof schemaSecret !== 'string') {
+    schemaSecret = undefined;
   }
 
   if (env && process.env[env]) {
     return process.env[env];
   }
 
-  let secret = schema.secret || env;
+  let secret = schemaSecret || env;
   if (secret && !ignoreSecrets) {
     if (prefix) {
       secret = `${prefix}${secret}`;

--- a/test/read-value.js
+++ b/test/read-value.js
@@ -115,4 +115,48 @@ suite('read-value:', () => {
       assert.isUndefined(error);
     });
   });
+
+  suite('non-string schema keys', () => {
+    let mockClient;
+    setup(() => {
+      mockClient = {
+        accessSecretVersion: sinon.stub(),
+        getSecretVersion: sinon.stub(),
+      };
+    });
+
+    test('read-value does not try to fetch secret from GCP when schema.secret is not a string', async () => {
+      await buildConfig({
+        client: mockClient,
+        project: GCP_PROJECT,
+        schema: {
+          email: {
+            secret: {
+              default: 'super-private',
+              doc: 'Crypto secret for email auth tokens',
+            },
+          },
+        },
+      });
+
+      assert.equal(mockClient.getSecretVersion.callCount, 0);
+    });
+
+    test('read-value does not try to fetch secret from GCP when schema.env is not a string', async () => {
+      await buildConfig({
+        client: mockClient,
+        project: GCP_PROJECT,
+        schema: {
+          email: {
+            env: {
+              default: 'interesting-env',
+              doc: 'Environment to use in CI for tests',
+            },
+          },
+        },
+      });
+
+      assert.equal(mockClient.getSecretVersion.callCount, 0);
+    });
+  });
 });


### PR DESCRIPTION

It might happen to have `schema.secret` to be an actual object defined in the config schema, if that's the case we should not try to read its value from GCP as we would incur in `INVALID_ARGUMENT` when trying to stringify an Object.

```
Error: 3 INVALID_ARGUMENT: 
The provided Secret Version ID [projects/xxxx/secrets/INTEGRATION_[object Object]/versions/latest] 
does not match the expected format [projects/*/secrets/*/versions/*]
```